### PR TITLE
Fix steering angle, throttle power, and brake power offsets not found…

### DIFF
--- a/Gears/Memory/VehicleExtensions.cpp
+++ b/Gears/Memory/VehicleExtensions.cpp
@@ -219,7 +219,7 @@ void VehicleExtensions::Init() {
     logger.Write(lightStatesOffset == 0 ? WARN : DEBUG, "Light States Offset: 0x%X", lightStatesOffset);
     // Or "8A 96 ? ? ? ? 0F B6 C8 84 D2 41", +10 or something (+31 is the engine starting bit), (0x928 starting addr)
 
-    addr = mem::FindPattern("\x74\x0A\xF3\x0F\x11\xB3\x1C\x09\x00\x00\xEB\x25", "xxxxxx????xx");
+    addr = mem::FindPattern("\x74\x0A\xF3\x0F\x11\xB3\x1C\x09\x00\x00\xEB\x25", "xxxxx?????xx");
     steeringAngleInputOffset = addr == 0 ? 0 : *(int*)(addr + 6);
     logger.Write(steeringAngleInputOffset == 0 ? WARN : DEBUG, "Steering Input Offset: 0x%X", steeringAngleInputOffset);
 


### PR DESCRIPTION
Related to #148

It's been a while in this repo. Looks like some people are giving you a hard time too badly, so I disassembled the new GTA5.exe to find what to fix and I managed to find one. It would be great if we could find a more stable place to extract the offset, but this change works at least.

The register to read got changed from `rbx` to `rdi` in the memory pattern `74 0A F3 0F 11 B3 ? ? ? ? EB 25`.
In b2944:
```
// 74 0A F3 0F 11 B3 ? ? ? ? EB 25
jz      short loc_7FF781A3D48E
movss   dword ptr [rbx+98Ch], xmm6
jmp     short loc_7FF781A3D4B3
```

In b3095:
```
// 74 0A F3 0F 11 B7 ? ? ? ? EB 25
jz      short loc_7FF7EFBE70AD
movss   dword ptr [rdi+9D4h], xmm6
jmp     short loc_7FF7EFBE70D2
```

Even with the register value to read ignored, we can find only one occurrence, even in b372 and b1604.

I know we have to make other memory patterns to patch how vehicle gears work, but still this PR would be a good start to support b3095.