### PR TITLE
Fix not nopping assembly code at 5 locations in b3095

### DIFF
--- a/Gears/Memory/MemoryPatcher.cpp
+++ b/Gears/Memory/MemoryPatcher.cpp
@@ -84,9 +84,9 @@ void SetPatterns(int version) {
         "xx????" "xxx?" "xxx?????" "xxx?????" "xx?" "xx?", 
         { 0xE9, 0x00, 0x00, 0x00, 0x00, 0x90 });
 
-    // Valid for 877 to 1868, in 2060 last byte changed to 0xC4
-    steeringControl = PatternInfo("\xF3\x0F\x11\x8B\xFC\x08\x00\x00" "\xF3\x0F\x10\x83\x00\x09\x00\x00" "\xF3\x0F\x58\x83\xFC\x08\x00\x00" "\x41\x0F\x2F\xC3",
-        "xxxx??xx" "xxxx??xx" "xxxx??xx" "xxx?", 
+    // Valid for 877 to 1868, in 2060 last byte changed to 0xC4, in 3095 general-purpose register changed to rdi
+    steeringControl = PatternInfo("\xF3\x0F\x11\x8B\xFC\x08\x00\x00" "\xF3\x0F\x10\x83\x00\x09\x00\x00" "\xF3\x0F\x58\x83\xFC\x08\x00\x00" "\x41\x0F\x2F\xC3" "\xF3\x0F\x11\x83\xFC\x08\x00\x00" "\x73\x06",
+        "xxx???xx" "xxx???xx" "xxx???xx" "xxx?" "xxx???xx" "xx",
         { 0x00, 0x00, 0x00, 0x00, 0x00, 0x00, 0x00, 0x00 });
 
     // Valid for 1604 (FiveM) to 1868+
@@ -148,9 +148,12 @@ void SetPatterns(int version) {
         shiftDown = PatternInfo("\x66\xFF\x0B\xC7\x43\x54\xCD\xCC\xCC\x3D", "xxxxxxxxxx",
             { 0x66, 0xFF, 0x0B });
         // the 2 offsets of CTransmission was shifted to 0x80 and 0x84 and the 2 mov opcodes changed
-        clutchRevLimit = PatternInfo("\xC7\x43\x54\xCD\xCC\xCC\x3D" "\x44\x89\xB3\x84\x00\x00\x00" "\x44\x89\xA3\x80\x00\x00\x00",
+        clutchRevLimit = PatternInfo("\xC7\x43\x54\xCD\xCC\xCC\x3D\x44\x89\xB3\x84\x00\x00\x00\x44\x89\xA3\x80\x00\x00\x00",
             "xx?xxxxxxx????xxx????",
-            { 0xC7, 0x43, 0x4C, 0xCD, 0xCC, 0xCC, 0x3D });
+            { 0xC7, 0x43, 0x54, 0xCD, 0xCC, 0xCC, 0x3D });
+        // register has changed
+        throttleLift = PatternInfo("\x89\x4F\x58\xF3\x44\x0F\x11", "xx?xxxx",
+            { 0x90, 0x90, 0x90 });
     }
 }
 

--- a/Gears/Memory/MemoryPatcher.cpp
+++ b/Gears/Memory/MemoryPatcher.cpp
@@ -140,6 +140,18 @@ void SetPatterns(int version) {
         throttleLift = PatternInfo("\x44\x89\x77\x50\xf3\x0f\x11", "xxxxxxx",
             { 0x90, 0x90, 0x90, 0x90 });
     }
+    if (version >= G_VER_1_0_3095_0) {
+        // compiler changed how to increment the current gear value
+        shiftUp = PatternInfo("\x66\x01\x2B\xC7\x43\x54\xCD\xCC\xCC\x3D", "xxxxxxxxxx",
+            { 0x66, 0x01, 0x2B, });
+        // compiler changed how to decrement the current gear value
+        shiftDown = PatternInfo("\x66\xFF\x0B\xC7\x43\x54\xCD\xCC\xCC\x3D", "xxxxxxxxxx",
+            { 0x66, 0xFF, 0x0B });
+        // the 2 offsets of CTransmission was shifted to 0x80 and 0x84 and the 2 mov opcodes changed
+        clutchRevLimit = PatternInfo("\xC7\x43\x54\xCD\xCC\xCC\x3D" "\x44\x89\xB3\x84\x00\x00\x00" "\x44\x89\xA3\x80\x00\x00\x00",
+            "xx?xxxxxxx????xxx????",
+            { 0xC7, 0x43, 0x4C, 0xCD, 0xCC, 0xCC, 0x3D });
+    }
 }
 
 bool Test() {

--- a/Gears/Memory/Versions.h
+++ b/Gears/Memory/Versions.h
@@ -261,6 +261,8 @@ enum G_GameVersion : int {
     G_VER_1_0_2824_0,           // 81
     G_VER_1_0_2845_0,           // 82
     G_VER_1_0_2944_0,           // 83
+    G_VER_1_0_3028_0,           // 84
+    G_VER_1_0_3095_0,           // 85
 };
 
 static std::vector<std::pair<SVersion, std::vector<int>>> ExeVersionMap = {


### PR DESCRIPTION
Related to #148

Still there's things to fix to work in b3095, but I think I should create another PR since I won't be able to disassemble the exe for a day.

I'm sure the memory patterns for auto gear shift and the clutch rev limit is in `CTransmission::ProcessGears`. You could take a look at how it is implemented in a debug build of `roadpathsgenerator_win64_beta` if you have it. In case we need other memory patterns due to how the function is compiled got changed again, you can find the call instruction that calls the `ProcessGears` function with the memory pattern `41 0F 94 C0 24 1F 3C 06 75 07 44 0F 28 CE 41 B0 01` (the first one is what we should look for, tested in b372, b2944, and b3095).